### PR TITLE
Fix query_pages not respecting limit argument

### DIFF
--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -36,7 +36,7 @@ maplit = "1.0"
 serde = "1.0"
 serde_json = "1.0"
 tokio = { version = "1", features = ["macros"] }
-lambda_http = { git = "https://github.com/awslabs/aws-lambda-rust-runtime/", branch = "master"}
+lambda_http = { git = "https://github.com/awslabs/aws-lambda-rust-runtime/", branch = "main"}
 trybuild = "1.0"
 rustversion = "1.0"
 dynomite-derive = { version = "0.10.0", path = "../dynomite-derive" } # required by trybuild

--- a/dynomite/Cargo.toml
+++ b/dynomite/Cargo.toml
@@ -25,8 +25,8 @@ futures = "0.3"
 log = "0.4"
 # Disable default features since the `rustls` variant requires it. We re-enable `default` in our
 # `default` build configuration - see the [features] below.
-rusoto_core = { git = "https://github.com/figma/rusoto", rev = "7f87da70eea21308de84cad174736099f1dd2472", optional = true, default_features = false }
-rusoto_dynamodb = { git = "https://github.com/figma/rusoto", rev = "7f87da70eea21308de84cad174736099f1dd2472", optional = true, default_features = false }
+rusoto_core = { version = "0.47", optional = true, default_features = false }
+rusoto_dynamodb = { version = "0.47", optional = true, default_features = false }
 uuid = { version = "0.8", features = ["v4"], optional = true }
 chrono = { version = "0.4", optional = true }
 

--- a/dynomite/src/ext.rs
+++ b/dynomite/src/ext.rs
@@ -160,6 +160,11 @@ where
                                 return Ok(None) as Result<_, RusotoError<QueryError>>
                             }
                         };
+                        if let Some(limit) = input.limit {
+                            if limit < 1 {
+                                return Ok(None) as Result<_, RusotoError<QueryError>>;
+                            }
+                        }
                         let resp = clone
                             .query(QueryInput {
                                 exclusive_start_key,

--- a/dynomite/src/ext.rs
+++ b/dynomite/src/ext.rs
@@ -154,7 +154,7 @@ where
                 move |state| {
                     let clone = self.clone();
                     async move {
-                        let (exclusive_start_key, input) = match state {
+                        let (exclusive_start_key, mut input) = match state {
                             PageState::Next(start, input) => (start, input),
                             PageState::End => {
                                 return Ok(None) as Result<_, RusotoError<QueryError>>
@@ -166,15 +166,18 @@ where
                                 ..input.clone()
                             })
                             .await?;
+                        let items = resp.items.unwrap_or_default().into_iter().map(Ok);
                         let next_state =
                             match resp.last_evaluated_key.filter(|next| !next.is_empty()) {
-                                Some(next) => PageState::Next(Some(next), input),
+                                Some(next) => {
+                                    if let Some(limit) = &mut input.limit {
+                                        *limit -= items.len() as i64;
+                                    }
+                                    PageState::Next(Some(next), input)
+                                }
                                 _ => PageState::End,
                             };
-                        Ok(Some((
-                            stream::iter(resp.items.unwrap_or_default().into_iter().map(Ok)),
-                            next_state,
-                        )))
+                        Ok(Some((stream::iter(items), next_state)))
                     }
                 },
             )


### PR DESCRIPTION
Limit should be decremented by the number of items returned from
the page.

Doesn't look like there are tests for query pages, so we should write tests
on our side to ensure that this works.